### PR TITLE
Adds splat output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If the file extension is `.z64`, `.n64`, or `.v64`, the tool will assume the fil
 
     -s                        scan for symbols from the built-in signature file
     -l <sig/lib/obj path(s)>  scan for symbols from signature/object/library file(s)
-    -f <output format>        set the output format (pj64, nemu, armips, n64split, default)
+    -f <output format>        set the output format (pj64, nemu, armips, n64split, splat, default)
     -o <output path>          set the output path
     -h <headersize>           set the header size  (default: 0x80000000)
     -t                        scan thoroughly
@@ -32,7 +32,7 @@ Scans against signature files and ELF libraries/objects. If a directory path is 
 
 #### `-f <format>`
 
-Sets the output format. Valid formats include `pj64`, `nemu`, `armips`, `n64split`, and `default`.
+Sets the output format. Valid formats include `pj64`, `nemu`, `armips`, `n64split`, `splat`, and `default`.
 
 | Format     | Description                             |
 |------------|-----------------------------------------|
@@ -40,6 +40,7 @@ Sets the output format. Valid formats include `pj64`, `nemu`, `armips`, `n64spli
 | `nemu`     | Nemu64 bookmarks (*.nbm)                |
 | `armips`   | armips labels (*.asm)                   |
 | `n64split` | n64split config labels (*.yaml)         |
+| `splat`    | splat symbol names (symbol_addrs.txt)   |
 | `default`  | Space-separated address and symbol name |
 
 #### `-o <output path>`

--- a/src/n64sym.cpp
+++ b/src/n64sym.cpp
@@ -33,7 +33,8 @@ CN64Sym::n64sym_fmt_lut_t CN64Sym::FormatNames[] = {
     { "pj64",     N64SYM_FMT_PJ64 },
     { "nemu",     N64SYM_FMT_NEMU },
     { "armips",   N64SYM_FMT_ARMIPS },
-    { "n64split", N64SYM_FMT_N64SPLIT }
+    { "n64split", N64SYM_FMT_N64SPLIT },
+    { "splat",    N64SYM_FMT_SPLAT}
 };
 
 CN64Sym::CN64Sym() :
@@ -277,6 +278,12 @@ void CN64Sym::DumpResults()
         for(auto &result : m_Results)
         {
             Output("   - [0x%08X, \"%s\"]\n", result.address, result.name);
+        }
+        break;
+    case N64SYM_FMT_SPLAT:
+        for(auto &result : m_Results)
+        {
+            Output("%s = 0x%08X;\n", result.name, result.address);
         }
         break;
     case N64SYM_FMT_DEFAULT:

--- a/src/n64sym.h
+++ b/src/n64sym.h
@@ -29,7 +29,8 @@ typedef enum
     N64SYM_FMT_PJ64,
     N64SYM_FMT_NEMU,
     N64SYM_FMT_ARMIPS,
-    N64SYM_FMT_N64SPLIT
+    N64SYM_FMT_N64SPLIT,
+    N64SYM_FMT_SPLAT
 } n64sym_output_fmt_t;
 
 class CN64Sym

--- a/src/n64sym_main.cpp
+++ b/src/n64sym_main.cpp
@@ -25,7 +25,7 @@ int main(int argc, const char* argv[])
             "  Options:\n"
             "    -s                         scan for symbols from built-in signature file\n"
             "    -l <sig/lib/obj path>      scan for symbols from signature/library/object file(s)\n"
-            "    -f <format>                set the output format (pj64, nemu, armips, n64split, default)\n"
+            "    -f <format>                set the output format (pj64, nemu, armips, n64split, splat, default)\n"
             "    -o <output path>           set the output path\n"
             "    -h <headersize>            set the headersize (default: 0x80000000)\n"
             "    -t                         scan thoroughly\n"


### PR DESCRIPTION
This adds the `splat` output format, which exports the function addresses in the format used by [splat](https://github.com/ethteck/splat)